### PR TITLE
Remove requirement for implementing ISanityDoc

### DIFF
--- a/src/client/Extensions/DocumentExtensions.cs
+++ b/src/client/Extensions/DocumentExtensions.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Olav.Sanity.Client.Mutators;
+
+
+namespace Olav.Sanity.Client.Extensions
+{
+    public static class DocumentExtensions
+    {
+        /// <summary>
+        /// Determines if object is a Sanity draft document by inspecting the Id field.
+        /// </summary>
+        /// <param name="document"></param>
+        /// <returns></returns>
+        public static bool IsDraftDocument(this object document)
+        {
+            if (document == null) return false;
+            var id = document.GetId();
+            if (id == null) return false;
+            return id.StartsWith("drafts.");
+        }
+
+        /// <summary>
+        /// Returns ID of a document based on conventions: Id, ID, _id, {className}Id etc.
+        /// </summary>
+        /// <param name="document">Object which is expected to represent a single Sanity document.</param>
+        /// <returns></returns>
+        public static string GetId(this object document)
+        {
+            if (document == null) return null;
+
+            // Return Id for documents implementing ISanityDoc
+            if (document is ISanityDoc)
+            {
+                return ((ISanityDoc)document).Id;
+            }
+
+            // Return Id for documents implementing IHaveId
+            if (document is IHaveId)
+            {
+                return ((IHaveId)document).Id;
+            }
+
+            // Return Id using reflection (based on conventions)
+            var idProperty = document.GetType().GetIdProperty();
+            if (idProperty != null)
+            {
+                return idProperty.GetValue(document)?.ToString();
+            }
+
+            // ID not found
+            return null;
+        }
+
+        private static ConcurrentDictionary<Type,PropertyInfo> _idPropertyCache = new ConcurrentDictionary<Type,PropertyInfo>();
+        private static PropertyInfo GetIdProperty(this Type type)
+        {
+            if (!_idPropertyCache.ContainsKey(type))
+            {
+                // Find Id property by convention (i.e. "Id", "ID", "_id", "{documentTypeName}Id" etc.)
+                var props = type.GetProperties();
+                var idProperty = props.FirstOrDefault(p => p.Name.Equals("id", StringComparison.InvariantCultureIgnoreCase) ||
+                                                           p.Name.Equals("_id", StringComparison.InvariantCultureIgnoreCase) ||
+                                                           p.Name.Equals($"{type.Name}id", StringComparison.InvariantCultureIgnoreCase)
+                    );
+                _idPropertyCache[type] = idProperty;
+            }
+            return _idPropertyCache[type];
+        }
+
+    }
+}

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Olav.Sanity.Client.Extensions;
 using Olav.Sanity.Client.Mutators;
 
 namespace Olav.Sanity.Client
@@ -97,7 +98,7 @@ namespace Olav.Sanity.Client
 
             var result = JsonConvert.DeserializeObject<T>(content);
             result.Result = excludeDrafts ?
-                                result.Result.Where(doc => !doc.Id.StartsWith("drafts.")).ToArray() :
+                                result.Result.Where(doc => !doc.IsDraftDocument()).ToArray() :
                                 result.Result;
 
             return (message.StatusCode, result);

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -88,7 +88,6 @@ namespace Olav.Sanity.Client
 
         private async Task<(HttpStatusCode, T)> FetchResultToResult<T, V>(HttpResponseMessage message, bool excludeDrafts)
                 where T : FetchResult<V>
-                where V : ISanityDoc
         {
             if (!message.IsSuccessStatusCode)
             {
@@ -110,7 +109,7 @@ namespace Olav.Sanity.Client
         /// <param name="query">GROQ query</param>
         /// <param name="excludeDrafts">set to false if unpublished documents should be included in the result</param>
         /// <returns>Tuple of HttpStatusCode and T's wrapped in a FetchResult</returns>
-        public virtual async Task<(HttpStatusCode, FetchResult<T>)> Fetch<T>(string query, bool excludeDrafts = true) where T : ISanityDoc
+        public virtual async Task<(HttpStatusCode, FetchResult<T>)> Fetch<T>(string query, bool excludeDrafts = true)
         {
             var encodedQ = System.Net.WebUtility.UrlEncode(query);
             var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}");


### PR DESCRIPTION
### Changes
Draft documents are determined from Id field based on conventions instead of requiring implementation of ISanityDoc.

Primarily implemented in a new DocumentExtensions class in the Olav.Sanity.Client.Extensions namespace.

See also comment here: https://github.com/onybo/sanity-client/pull/1