### PR TITLE
Query function for arbitrary values

### DIFF
--- a/src/client/FetchResult.cs
+++ b/src/client/FetchResult.cs
@@ -1,9 +1,6 @@
 namespace Olav.Sanity.Client
 {
-    public class FetchResult<T>
+    public class FetchResult<T> : QueryResult<T[]>
     {
-        public int Ms { get; set; }
-        public string Query { get; set; }
-        public T[] Result { get; set; }
     }
 }

--- a/src/client/QueryResult.cs
+++ b/src/client/QueryResult.cs
@@ -1,0 +1,9 @@
+namespace Olav.Sanity.Client
+{
+    public class QueryResult<T>
+    {
+        public int Ms { get; set; }
+        public string Query { get; set; }
+        public T Result { get; set; }
+    }
+}

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -125,8 +125,8 @@ namespace Olav.Sanity.Client
         public virtual async Task<(HttpStatusCode, QueryResult<T>)> Query<T>(string query)
         {
             var encodedQ = System.Net.WebUtility.UrlEncode(query);
-            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}");
-            return await QueryResultToResult<QueryResult<T>, T>(message, false);
+            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}").ConfigureAwait(false);
+            return await QueryResultToResult<QueryResult<T>, T>(message, false).ConfigureAwait(false);
         }
 
         private async Task<(HttpStatusCode, T)> QueryResultToResult<T, V>(HttpResponseMessage message, bool excludeDrafts)


### PR DESCRIPTION
### Improvments
Added a new Query function. This is almost identical to Fetch, but does not require that the result is an array, meaning it can be used to retrieve not-array results, such as a "count" query or a single field.

> Function naming is not optimal, as discussed in https://github.com/onybo/sanity-client/pull/1. However, this was to avoid breaking changes. A new pull request with suggested naming will be added.