### PR TITLE
Suggested method renames

### DIFF
--- a/src/client/Extensions/DocumentExtensions.cs
+++ b/src/client/Extensions/DocumentExtensions.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Olav.Sanity.Client.Mutators;
+
+
+namespace Olav.Sanity.Client.Extensions
+{
+    public static class DocumentExtensions
+    {
+        /// <summary>
+        /// Determines if object is a Sanity draft document by inspecting the Id field.
+        /// </summary>
+        /// <param name="document"></param>
+        /// <returns></returns>
+        public static bool IsDraftDocument(this object document)
+        {
+            if (document == null) return false;
+            var id = document.GetId();
+            if (id == null) return false;
+            return id.StartsWith("drafts.");
+        }
+
+        /// <summary>
+        /// Returns ID of a document based on conventions: Id, ID, _id, {className}Id etc.
+        /// </summary>
+        /// <param name="document">Object which is expected to represent a single Sanity document.</param>
+        /// <returns></returns>
+        public static string GetId(this object document)
+        {
+            if (document == null) return null;
+
+            // Return Id for documents implementing ISanityDoc
+            if (document is ISanityDoc)
+            {
+                return ((ISanityDoc)document).Id;
+            }
+
+            // Return Id for documents implementing IHaveId
+            if (document is IHaveId)
+            {
+                return ((IHaveId)document).Id;
+            }
+
+            // Return Id using reflection (based on conventions)
+            var idProperty = document.GetType().GetIdProperty();
+            if (idProperty != null)
+            {
+                return idProperty.GetValue(document)?.ToString();
+            }
+
+            // ID not found
+            return null;
+        }
+
+        private static ConcurrentDictionary<Type,PropertyInfo> _idPropertyCache = new ConcurrentDictionary<Type,PropertyInfo>();
+        private static PropertyInfo GetIdProperty(this Type type)
+        {
+            if (!_idPropertyCache.ContainsKey(type))
+            {
+                // Find Id property by convention (i.e. "Id", "ID", "_id", "{documentTypeName}Id" etc.)
+                var props = type.GetProperties();
+                var idProperty = props.FirstOrDefault(p => p.Name.Equals("id", StringComparison.InvariantCultureIgnoreCase) ||
+                                                           p.Name.Equals("_id", StringComparison.InvariantCultureIgnoreCase) ||
+                                                           p.Name.Equals($"{type.Name}id", StringComparison.InvariantCultureIgnoreCase)
+                    );
+                _idPropertyCache[type] = idProperty;
+            }
+            return _idPropertyCache[type];
+        }
+
+    }
+}

--- a/src/client/FetchResult.cs
+++ b/src/client/FetchResult.cs
@@ -1,9 +1,6 @@
 namespace Olav.Sanity.Client
 {
-    public class FetchResult<T>
+    public class FetchResult<T> : QueryResult<T[]>
     {
-        public int Ms { get; set; }
-        public string Query { get; set; }
-        public T[] Result { get; set; }
     }
 }

--- a/src/client/QueryResult.cs
+++ b/src/client/QueryResult.cs
@@ -1,0 +1,9 @@
+namespace Olav.Sanity.Client
+{
+    public class QueryResult<T>
+    {
+        public int Ms { get; set; }
+        public string Query { get; set; }
+        public T Result { get; set; }
+    }
+}

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Olav.Sanity.Client.Extensions;
 using Olav.Sanity.Client.Mutators;
 
 namespace Olav.Sanity.Client
@@ -97,7 +98,7 @@ namespace Olav.Sanity.Client
 
             var result = JsonConvert.DeserializeObject<T>(content);
             result.Result = excludeDrafts ?
-                                result.Result.Where(doc => !doc.Id.StartsWith("drafts.")).ToArray() :
+                                result.Result.Where(doc => !doc.IsDraftDocument()).ToArray() :
                                 result.Result;
 
             return (message.StatusCode, result);

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -88,7 +88,6 @@ namespace Olav.Sanity.Client
 
         private async Task<(HttpStatusCode, T)> FetchResultToResult<T, V>(HttpResponseMessage message, bool excludeDrafts)
                 where T : FetchResult<V>
-                where V : ISanityDoc
         {
             if (!message.IsSuccessStatusCode)
             {
@@ -110,7 +109,7 @@ namespace Olav.Sanity.Client
         /// <param name="query">GROQ query</param>
         /// <param name="excludeDrafts">set to false if unpublished documents should be included in the result</param>
         /// <returns>Tuple of HttpStatusCode and T's wrapped in a FetchResult</returns>
-        public virtual async Task<(HttpStatusCode, FetchResult<T>)> Fetch<T>(string query, bool excludeDrafts = true) where T : ISanityDoc
+        public virtual async Task<(HttpStatusCode, FetchResult<T>)> Fetch<T>(string query, bool excludeDrafts = true)
         {
             var encodedQ = System.Net.WebUtility.UrlEncode(query);
             var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}");

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -70,8 +70,8 @@ namespace Olav.Sanity.Client
         /// <returns>Tuple of HttpStatusCode and a T wrapped in a DocumentResult</returns>
         public virtual async Task<(HttpStatusCode, DocumentResult<T>)> GetDocument<T>(string id) where T : class
         {
-            var message = await _httpClient.GetAsync($"doc/{_dataset}/{id}");
-            return await ResponseToResult<DocumentResult<T>>(message);
+            var message = await _httpClient.GetAsync($"doc/{_dataset}/{id}").ConfigureAwait(false);
+            return await ResponseToResult<DocumentResult<T>>(message).ConfigureAwait(false);
         }
 
         private async Task<(HttpStatusCode, T)> ResponseToResult<T>(HttpResponseMessage message) where T : class
@@ -80,7 +80,7 @@ namespace Olav.Sanity.Client
             {
                 return (message.StatusCode, null);
             }
-            var content = await message.Content.ReadAsStringAsync();
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return (message.StatusCode, JsonConvert.DeserializeObject<T>(content));
         }
@@ -93,7 +93,7 @@ namespace Olav.Sanity.Client
             {
                 return (message.StatusCode, null);
             }
-            var content = await message.Content.ReadAsStringAsync();
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var result = JsonConvert.DeserializeObject<T>(content);
             result.Result = excludeDrafts ?
@@ -112,8 +112,8 @@ namespace Olav.Sanity.Client
         public virtual async Task<(HttpStatusCode, FetchResult<T>)> Fetch<T>(string query, bool excludeDrafts = true) where T : ISanityDoc
         {
             var encodedQ = System.Net.WebUtility.UrlEncode(query);
-            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}");
-            return await FetchResultToResult<FetchResult<T>, T>(message, excludeDrafts);
+            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}").ConfigureAwait(false);
+            return await FetchResultToResult<FetchResult<T>, T>(message, excludeDrafts).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -130,8 +130,8 @@ namespace Olav.Sanity.Client
             var json = mutations.Serialize();
             var content = new StringContent(json);
             var url = $"mutate/{_dataset}?returnIds={returnIds.ToString().ToLower()}&returnDocuments={returnDocuments.ToString().ToLower()}&visibility={visibility.ToString().ToLower()}";
-            var message = await _httpClient.PostAsync(url, content);
-            return await ResponseToResult<MutationResult>(message);
+            var message = await _httpClient.PostAsync(url, content).ConfigureAwait(false);
+            return await ResponseToResult<MutationResult>(message).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -155,6 +155,13 @@ namespace Olav.Sanity.Client
             return (message.StatusCode, result);
         }
 
+        [Obsolete("Use MutateAsync method instead.")]
+        public virtual Task<(HttpStatusCode, MutationResult)> Mutate(
+            Mutations mutations, bool returnIds = false, bool returnDocuments = false,
+            Visibility visibility = Visibility.Sync)
+        {
+            return MutateAsync(mutations, returnIds, returnDocuments, visibility);
+        }
 
         /// <summary>
         /// Change one or more document using the given Mutations

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -125,8 +125,8 @@ namespace Olav.Sanity.Client
         public virtual async Task<(HttpStatusCode, QueryResult<T>)> Query<T>(string query)
         {
             var encodedQ = System.Net.WebUtility.UrlEncode(query);
-            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}");
-            return await QueryResultToResult<QueryResult<T>, T>(message, false);
+            var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}").ConfigureAwait(false);
+            return await QueryResultToResult<QueryResult<T>, T>(message, false).ConfigureAwait(false);
         }
 
         private async Task<(HttpStatusCode, T)> QueryResultToResult<T, V>(HttpResponseMessage message, bool excludeDrafts)


### PR DESCRIPTION
1. Rename Fetch to GetDocuments
2. Add Async suffix to async method names (to follow conventions)
3. Added [Obsolete] methods for backwards compatiblity.

This pull request builds on previous pull-requests: #3 #4 #5 
The essence of the changes are in commit https://github.com/onybo/sanity-client/commit/1d82e0970dde52fb3e9ce189ffaccb50373cf91a and https://github.com/onybo/sanity-client/commit/c9c6b8acc96d17f31623d2ac8cdc9ee871aca268