### PR TITLE
.net5.0 support + Replace Newtonsoft with System.Text.Json

### DIFF
--- a/src/client/Extensions/DocumentExtensions.cs
+++ b/src/client/Extensions/DocumentExtensions.cs
@@ -1,13 +1,7 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Reflection;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Olav.Sanity.Client.Mutators;
 
 

--- a/src/client/ISanityDoc.cs
+++ b/src/client/ISanityDoc.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace Olav.Sanity.Client
 {
     public interface ISanityDoc

--- a/src/client/JsonOptions.cs
+++ b/src/client/JsonOptions.cs
@@ -4,7 +4,7 @@ namespace Olav.Sanity.Client
 {
     public static class JsonOptions
     {
-        public static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new()
+        public static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new JsonSerializerOptions()
         {
             PropertyNameCaseInsensitive = true
         };

--- a/src/client/JsonOptions.cs
+++ b/src/client/JsonOptions.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace Olav.Sanity.Client
+{
+    public static class JsonOptions
+    {
+        public static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+}

--- a/src/client/Mutators/IHaveId.cs
+++ b/src/client/Mutators/IHaveId.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Olav.Sanity.Client.Mutators
 {
     public interface IHaveId
     {
-        [JsonProperty("_id")]
-        string Id {get;}        
+        [JsonPropertyName("_id")]
+        string Id {get;}
     }
 }

--- a/src/client/Mutators/ISanityType.cs
+++ b/src/client/Mutators/ISanityType.cs
@@ -1,11 +1,10 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Olav.Sanity.Client.Mutators
 {
     public interface ISanityType
     {
-        [JsonProperty("_type")]
+        [JsonPropertyName("_type")]
         string SanityTypeName { get; }
     }
 }

--- a/src/client/Mutators/Mutations.cs
+++ b/src/client/Mutators/Mutations.cs
@@ -1,13 +1,12 @@
 using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Olav.Sanity.Client.Mutators
 {
     public class Mutations
     {
-        [JsonProperty(PropertyName = "Mutations")]
+        [JsonPropertyName("Mutations")]
         private readonly List<object> _mutations;
 
 
@@ -44,15 +43,15 @@ namespace Olav.Sanity.Client.Mutators
 
         public string Serialize()
         {
-            return JsonConvert.SerializeObject(
-                        this,
-                        Formatting.Indented,
-                        new JsonSerializerSettings
-                        {
-                            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                            NullValueHandling = NullValueHandling.Ignore
-                        }
-                    );
+            return JsonSerializer.Serialize(
+                this,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    IgnoreNullValues = true,
+                    WriteIndented = true
+                }
+            );
         }
     }
 }

--- a/src/client/SanityClient.cs
+++ b/src/client/SanityClient.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Olav.Sanity.Client.Extensions;
 using Olav.Sanity.Client.Mutators;
 using Olav.Sanity.Client.Transactions;
@@ -86,7 +86,7 @@ namespace Olav.Sanity.Client
             }
             var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            return (message.StatusCode, JsonConvert.DeserializeObject<T>(content));
+            return (message.StatusCode, JsonSerializer.Deserialize<T>(content, JsonOptions.DefaultJsonSerializerOptions));
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Olav.Sanity.Client
         /// <returns>Tuple of HttpStatusCode and T's wrapped in a QueryResult</returns>
         public virtual async Task<(HttpStatusCode, QueryResult<T[]>)> Query<T>(string query, bool excludeDrafts = true)
         {
-            var encodedQ = System.Net.WebUtility.UrlEncode(query);
+            var encodedQ = WebUtility.UrlEncode(query);
             var message = await _httpClient.GetAsync($"query/{_dataset}?query={encodedQ}").ConfigureAwait(false);
             return await QueryResultToResult<QueryResult<T[]>, T>(message, excludeDrafts).ConfigureAwait(false);
         }
@@ -113,7 +113,7 @@ namespace Olav.Sanity.Client
             }
             var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var result = JsonConvert.DeserializeObject<T>(content);
+            var result = JsonSerializer.Deserialize<T>(content, JsonOptions.DefaultJsonSerializerOptions);
             result.Result = excludeDrafts ?
                                 result.Result.Where(doc => !doc.IsDraftDocument()).ToArray() :
                                 result.Result;
@@ -143,7 +143,7 @@ namespace Olav.Sanity.Client
             }
             var content = await message.Content.ReadAsStringAsync();
 
-            var result = JsonConvert.DeserializeObject<T>(content);
+            var result = JsonSerializer.Deserialize<T>(content, JsonOptions.DefaultJsonSerializerOptions);
 
             return (message.StatusCode, result);
         }

--- a/src/client/Transactions/NDJsonConvert.cs
+++ b/src/client/Transactions/NDJsonConvert.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Olav.Sanity.Client.Transactions
 {
@@ -11,7 +11,7 @@ namespace Olav.Sanity.Client.Transactions
         {
             var jsonSegments = ndJson.Split(Environment.NewLine.ToCharArray());
             return jsonSegments.Where(json => !string.IsNullOrWhiteSpace(json))
-                .Select(JsonConvert.DeserializeObject<T>)
+                .Select(json => JsonSerializer.Deserialize<T>(json, JsonOptions.DefaultJsonSerializerOptions))
                 .ToList();
         }
     }

--- a/src/client/sanity-client.csproj
+++ b/src/client/sanity-client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Olav Nybø</Authors>
     <PackageProjectUrl>https://github.com/onybo/sanity-client</PackageProjectUrl>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/client/sanity-client.csproj
+++ b/src/client/sanity-client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Olav Nybø</Authors>
     <PackageProjectUrl>https://github.com/onybo/sanity-client</PackageProjectUrl>

--- a/test/client.tests/client.tests.csproj
+++ b/test/client.tests/client.tests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Switching to system text json for better net5.0 support. Target net5.0 because of microsoft recommandation (Use net5.0 for code sharing moving forward): https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/